### PR TITLE
Update CI tools configuration

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,24 @@
+filter:
+  excluded_paths:
+    - 'tests/*'
+
+build:
+  environment:
+    php: 7.3
+  tests:
+    override:
+      - true
+  nodes:
+    analysis:
+      dependencies:
+        after:
+            - vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/
+      tests:
+        override:
+          - php-scrutinizer-run
+          - phpcs-run
+
+tools:
+  external_code_coverage:
+    runs: 1          # Scrutinizer will wait for one code coverage submission (integration test suite)
+    timeout: 2400    # Timeout in seconds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,38 @@
 os: linux
-dist: trusty
+dist: xenial
 group: edge
 services:
-  - elasticsearch
+  - mysql
 addons:
   apt:
     packages:
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6
       - postfix
   hosts:
     - magento2.travis
 language: php
 jobs:
   include:
-    - php: 7.3
-      env:
-        - MAGENTO_VERSION=2.3
-        - TEST_SUITE=integration
-    - php: 7.3
-      env:
-        - MAGENTO_VERSION=2.4-develop
-        - TEST_SUITE=integration
     - php: 7.2
       env:
         - MAGENTO_VERSION=2.3
+        - TEST_SUITE=integration
+    - php: 7.3
+      env:
+        - MAGENTO_VERSION=2.3
+        - TEST_SUITE=integration
+    - php: 7.4
+      env:
+        - MAGENTO_VERSION=2.4
+        - TEST_SUITE=integration
+        - COVERAGE=true
+    - php: 7.4
+      env:
+        - MAGENTO_VERSION=2.4-develop
+        - TEST_SUITE=integration
+  allow_failures:
+    - php: 7.4
+      env:
+        - MAGENTO_VERSION=2.4-develop
         - TEST_SUITE=integration
 env:
   global:
@@ -35,12 +42,21 @@ cache:
   apt: true
   directories:
     - $HOME/.composer/cache
+before_install:
+  - |
+    [[ $TEST_SUITE == "unit" ]] || (
+    curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb
+    sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb
+    sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+    sudo service elasticsearch restart
+    )
 before_script:
   - |
     sleep 10
+      [[ $COVERAGE == "true" ]] || phpenv config-rm xdebug.ini
     ./.travis/before_script.sh
-script: phpunit -c magento2/dev/tests/$TEST_SUITE --coverage-text --coverage-clover=/tmp/coverage.clover
+script: phpunit -c magento2/dev/tests/$TEST_SUITE `[[ $COVERAGE == "true" ]] && echo "--coverage-text --coverage-clover=/tmp/coverage.clover"`
 after_script:
   - |
-    wget https://scrutinizer-ci.com/ocular.phar
-    php ocular.phar code-coverage:upload --format=php-clover /tmp/coverage.clover
+    [[ $COVERAGE == "true" ]] && wget https://scrutinizer-ci.com/ocular.phar
+    [[ $COVERAGE == "true" ]] && php ocular.phar code-coverage:upload --format=php-clover /tmp/coverage.clover

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 trap '>&2 echo Error: Command \`$BASH_COMMAND\` on line $LINENO failed with exit code $?' ERR
 
 # mock mail
@@ -23,19 +23,29 @@ cd magento2
 
 # add composer package under test, composer require will trigger update/install
 composer config minimum-stability dev
-composer config repositories.travis_to_test git https://github.com/$TRAVIS_REPO_SLUG.git
-
+composer config repositories.travis_to_test git https://github.com/${TRAVIS_REPO_SLUG}.git
 if [ ! -z $TRAVIS_TAG  ]
 then
     composer require ${COMPOSER_PACKAGE_NAME}:${TRAVIS_TAG}
+elif [ ! -z $TRAVIS_PULL_REQUEST_BRANCH ]
+then
+    # For pull requests, use the remote repository
+    composer config repositories.travis_to_test git https://github.com/${TRAVIS_PULL_REQUEST_SLUG}.git
+    composer require ${COMPOSER_PACKAGE_NAME}:dev-${TRAVIS_PULL_REQUEST_BRANCH}\#${TRAVIS_PULL_REQUEST_SHA}
 else
     composer require ${COMPOSER_PACKAGE_NAME}:dev-${TRAVIS_BRANCH}\#${TRAVIS_COMMIT}
 fi
 
+# Add tests/src to autoload-dev on project level
+php -r '$composer_json = json_decode(file_get_contents("composer.json"), true);
+$composer_json["autoload-dev"]["psr-4"]["IntegerNet\\GlobalCustomLayout\\"] = "vendor/integer-net/magento2-global-custom-layout/tests/src";
+file_put_contents("composer.json", json_encode($composer_json));'
+composer dumpautoload
+
 # prepare for test suite
 case $TEST_SUITE in
     integration)
-        cp vendor/$COMPOSER_PACKAGE_NAME/tests/Integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
+        cp vendor/$COMPOSER_PACKAGE_NAME/tests/integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
 
         cd dev/tests/integration
 
@@ -44,12 +54,15 @@ case $TEST_SUITE in
             SET @@global.sql_mode = NO_ENGINE_SUBSTITUTION;
             CREATE DATABASE magento_integration_tests;
         '
-        cp etc/install-config-mysql.travis.php.dist etc/install-config-mysql.php
+        cp etc/install-config-mysql.php.dist etc/install-config-mysql.php
+        # Remove AMQP configuration
         sed -i '/amqp/d' etc/install-config-mysql.php
+        # Remove default root password
+        sed -i 's/123123q//' etc/install-config-mysql.php
 
         cd ../../..
-        ;;
+    ;;
     unit)
-        cp vendor/$COMPOSER_PACKAGE_NAME/tests/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
+        cp vendor/$COMPOSER_PACKAGE_NAME/tests/unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
     ;;
 esac

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -45,7 +45,7 @@ composer dumpautoload
 # prepare for test suite
 case $TEST_SUITE in
     integration)
-        cp vendor/$COMPOSER_PACKAGE_NAME/tests/integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
+        cp vendor/$COMPOSER_PACKAGE_NAME/tests/Integration/phpunit.xml.dist dev/tests/integration/phpunit.xml
 
         cd dev/tests/integration
 
@@ -63,6 +63,6 @@ case $TEST_SUITE in
         cd ../../..
     ;;
     unit)
-        cp vendor/$COMPOSER_PACKAGE_NAME/tests/unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
+        cp vendor/$COMPOSER_PACKAGE_NAME/tests/Unit/phpunit.xml.dist dev/tests/unit/phpunit.xml
     ;;
 esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2020-04-27
+## 1.1.2 - 2020-05-11
 ### Added
-- Plugins for category, product and page layouts that allow custom layout files to be loaded with a global identifier
- (`0`). E.g. `catalog_category_view_selectable_0_.xml` for Categories.
-
-## 1.1.0 - 2020-05-02
-### Added
-- Adds frontend test coverage for global custom layout updates
-- Fixes [#7](https://github.com/integer-net/magento2-global-custom-layout/issues/7) where layout handles were not merged in Product and Page Plugins' `afterFetchAvailableFiles()` method.
+- Updates travis, magento 2.4-dev now requires elasticsearch
+- Adds return type declaration (`void`) to `setUp()` functions, now needed for magento 2.4
 
 ## 1.1.1 - 2020-05-08
 ### Added
 - Adds module registration test (registration.php coverage)
 - Adds travis config for tags/releases
 
-## 1.1.2 - 2020-05-11
+## 1.1.0 - 2020-05-02
 ### Added
-- Updates travis, magento 2.4-dev now requires elasticsearch
-- Adds return type declaration (`void`) to `setUp()` functions, now needed for magento 2.4
+- Adds frontend test coverage for global custom layout updates
+- Fixes [#7](https://github.com/integer-net/magento2-global-custom-layout/issues/7) where layout handles were not merged in Product and Page Plugins' `afterFetchAvailableFiles()` method.
+
+## 1.0.0 - 2020-04-27
+### Added
+- Plugins for category, product and page layouts that allow custom layout files to be loaded with a global identifier
+ (`0`). E.g. `catalog_category_view_selectable_0_.xml` for Categories.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status][ico-travis]][link-travis]
 [![Coverage Status][ico-scrutinizer]][link-scrutinizer]
 [![Quality Score][ico-code-quality]][link-code-quality]
+![Supported Magento Versions][ico-compatibility]
 
 Allows you to add global layout update files to be selected from admin, by using `0` instead of a `category_id` / `sku` / `url_path`.
 
@@ -92,6 +93,7 @@ The MIT License (MIT). Please see [License File](LICENSE.txt) for more informati
 [ico-travis]: https://img.shields.io/travis/integer-net/magento2-global-custom-layout/master.svg?style=flat-square
 [ico-scrutinizer]: https://scrutinizer-ci.com/g/integer-net/magento2-global-custom-layout/badges/coverage.png?b=master
 [ico-code-quality]: https://img.shields.io/scrutinizer/g/integer-net/magento2-global-custom-layout.svg?style=flat-square
+[ico-compatibility]: https://img.shields.io/badge/magento-%202.3%20|%202.4-brightgreen.svg?logo=magento&longCache=true&style=flat-square
 
 [link-packagist]: https://packagist.org/packages/integer-net/magento2-global-custom-layout
 [link-travis]: https://travis-ci.org/integer-net/magento2-global-custom-layout

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,8 @@
         }
     ],
     "require-dev": {
+        "phpro/grumphp": "^v0.21.0",
+        "phpstan/phpstan": "^0.12.0",
         "magento/magento-coding-standard": "@dev"
     }
 }

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,0 +1,12 @@
+grumphp:
+    tasks:
+      composer: []
+      phpcs: ~
+      phpstan:
+          configuration: phpstan.neon
+      phpparser:
+          visitors:
+              no_exit_statements: ~
+              forbidden_function_calls:
+                  blacklist:
+                      - 'var_dump'

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset>
+    <exclude-pattern>tests/</exclude-pattern>
+    <rule ref="Magento2"/>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 6
+    paths:
+        - src
+        - tests
+    ignoreErrors:
+        - '#(class|type) Magento\\TestFramework#i'
+        - '#(class|type) Magento\\\S*Factory#i'
+        - '#(method) Magento\\Framework\\Api\\ExtensionAttributesInterface#i'


### PR DESCRIPTION
## Travis CI

- coverage only once per test suite
- do not rely on etc/install-config-mysql.travis.php.dist anymore
- configure autoload-dev
- allow building of pull requests
- install Elasticsearch 7.6.2
- test on PHP 7.4
- allow failures on 2.4-develop, test on 2.4 stable

## Scrutinizer

- Add configuration, run Magento Coding Standard test

## GrumPHP

- Added with phpcs and phpstan